### PR TITLE
Init digital ocean client

### DIFF
--- a/lib/astral_plane.rb
+++ b/lib/astral_plane.rb
@@ -1,6 +1,7 @@
 require "astral_plane/version"
 require 'astral_plane/http_client/abstract_http_client'
 require 'astral_plane/http_client/heroku'
+require 'astral_plane/http_client/digital_ocean'
 
 module AstralPlane
   class Error < StandardError; end

--- a/lib/astral_plane/http_client/abstract_http_client.rb
+++ b/lib/astral_plane/http_client/abstract_http_client.rb
@@ -16,7 +16,7 @@ class AstralPlane::AbstractHttpClient
         http = Net::HTTP.new(uri.host, uri.port)
         request = Object.const_get("Net::HTTP::#{value}").new(uri.request_uri)
         request['Authorization'] = "Bearer: #{token}"
-        request['content-type'] = "application/json"
+        request['Content-Type'] = "application/json"
         request.body = body if body
 
         get_response(http, request)

--- a/lib/astral_plane/http_client/abstract_http_client.rb
+++ b/lib/astral_plane/http_client/abstract_http_client.rb
@@ -24,17 +24,20 @@ class AstralPlane::AbstractHttpClient
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Get.new(uri.request_uri)
     request['Authorization'] = "Bearer: #{token}"
+    request['content-type'] = "application/json"
 
-    [request, http]
+    get_response(http, request)
   end
 
-  def self.post(base_url, endpoint, token)
+  def self.post(base_url, endpoint, body, token)
     uri = URI.parse(base_url + endpoint)
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Post.new(uri.request_uri)
     request['Authorization'] = "Bearer: #{token}"
+    request['content-type'] = "application/json"
+    request.body = body
 
-    [request, http]
+    get_response(http, request)
   end
 
   def self.delete(base_url, endpoint, token)
@@ -42,8 +45,9 @@ class AstralPlane::AbstractHttpClient
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Delete.new(uri.request_uri)
     request['Authorization'] = "Bearer: #{token}"
+    request['content-type'] = "application/json"
 
-    [request, http]
+    get_response(http, request)
   end
 
   def self.get_response(http, request)

--- a/lib/astral_plane/http_client/abstract_http_client.rb
+++ b/lib/astral_plane/http_client/abstract_http_client.rb
@@ -28,6 +28,24 @@ class AstralPlane::AbstractHttpClient
     [request, http]
   end
 
+  def self.post(base_url, endpoint, token)
+    uri = URI.parse(base_url + endpoint)
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request['Authorization'] = "Bearer: #{token}"
+
+    [request, http]
+  end
+
+  def self.delete(base_url, endpoint, token)
+    uri = URI.parse(base_url + endpoint)
+    http = Net::HTTP.new(uri.host, uri.port)
+    request = Net::HTTP::Delete.new(uri.request_uri)
+    request['Authorization'] = "Bearer: #{token}"
+
+    [request, http]
+  end
+
   def self.get_response(http, request)
     http.request(request)
   end

--- a/lib/astral_plane/http_client/abstract_http_client.rb
+++ b/lib/astral_plane/http_client/abstract_http_client.rb
@@ -3,6 +3,27 @@ require 'uri'
 
 class AstralPlane::AbstractHttpClient
 
+  METHODS = {
+    :post => "Post",
+    :get => "Get",
+    :delete => "Delete"
+  }.freeze
+
+  class << self
+    METHODS.each do |key, value|
+      define_method(key) do |base_url, endpoint, token, body|
+        uri = URI.parse(base_url + endpoint)
+        http = Net::HTTP.new(uri.host, uri.port)
+        request = Object.const_get("Net::HTTP::#{value}").new(uri.request_uri)
+        request['Authorization'] = "Bearer: #{token}"
+        request['content-type'] = "application/json"
+        request.body = body if body
+
+        get_response(http, request)
+      end
+    end
+  end
+
   def self.restart_server
     raise NotImplementedError
   end
@@ -17,37 +38,6 @@ class AstralPlane::AbstractHttpClient
 
   def self.list_servers
     raise NotImplementedError
-  end
-
-  def self.get(base_url, endpoint, token)
-    uri = URI.parse(base_url + endpoint)
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Get.new(uri.request_uri)
-    request['Authorization'] = "Bearer: #{token}"
-    request['content-type'] = "application/json"
-
-    get_response(http, request)
-  end
-
-  def self.post(base_url, endpoint, body, token)
-    uri = URI.parse(base_url + endpoint)
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Post.new(uri.request_uri)
-    request['Authorization'] = "Bearer: #{token}"
-    request['content-type'] = "application/json"
-    request.body = body
-
-    get_response(http, request)
-  end
-
-  def self.delete(base_url, endpoint, token)
-    uri = URI.parse(base_url + endpoint)
-    http = Net::HTTP.new(uri.host, uri.port)
-    request = Net::HTTP::Delete.new(uri.request_uri)
-    request['Authorization'] = "Bearer: #{token}"
-    request['content-type'] = "application/json"
-
-    get_response(http, request)
   end
 
   def self.get_response(http, request)

--- a/lib/astral_plane/http_client/digital_ocean.rb
+++ b/lib/astral_plane/http_client/digital_ocean.rb
@@ -1,48 +1,22 @@
 class AstralPlane::DigitalOcean < AstralPlane::AbstractHttpClient
   BASE_URL = 'https://api.digitalocean.com/v2/'.freeze
+  # TODO: set this token in config
+  TOKEN = AstralPlane.digital_ocean_token
 
   def self.restart_server(droplet_id)
     body = '{"type":"reboot"}'
-    post("droplets/#{droplet_id}/actions", body, "token")
+    post(BASE_URL, "droplets/#{droplet_id}/actions", body, TOKEN)
   end
 
   def self.create_server(body)
-    post("droplets", body, "token")
+    post(BASE_URL, "droplets", body, TOKEN)
   end
 
   def self.delete_server(droplet_id)
-    delete("droplets/#{droplet_id}", "token")
+    delete(BASE_URL, "droplets/#{droplet_id}", TOKEN)
   end
 
   def self.list_servers
-    get("droplets", "token")
-  end
-
-  def self.get(base_url = BASE_URL, endpoint, token)
-    super_array = super
-    request = super_array[0]
-    http = super_array[1]
-    request['content-type'] = "application/json"
-
-    get_response(http, request)
-  end
-
-  def self.post(base_url = BASE_URL, endpoint, body, token)
-    super_array = super
-    request = super_array[0]
-    http = super_array[1]
-    request['content-type'] = "application/json"
-    request.body = body
-
-    get_response(http, request)
-  end
-
-  def self.delete(base_url = BASE_URL, endpoint, token)
-    super_array = super
-    request = super_array[0]
-    http = super_array[1]
-    request['content-type'] = "application/json"
-
-    get_response(http, request)
+    get(BASE_URL, "droplets", TOKEN)
   end
 end

--- a/lib/astral_plane/http_client/digital_ocean.rb
+++ b/lib/astral_plane/http_client/digital_ocean.rb
@@ -1,22 +1,22 @@
 class AstralPlane::DigitalOcean < AstralPlane::AbstractHttpClient
   BASE_URL = 'https://api.digitalocean.com/v2/'.freeze
   # TODO: set this token in config
-  TOKEN = AstralPlane.digital_ocean_token
+  TOKEN = "token"
 
   def self.restart_server(droplet_id)
     body = '{"type":"reboot"}'
-    post(BASE_URL, "droplets/#{droplet_id}/actions", body, TOKEN)
+    post(BASE_URL, "droplets/#{droplet_id}/actions", TOKEN, body)
   end
 
   def self.create_server(body)
-    post(BASE_URL, "droplets", body, TOKEN)
+    post(BASE_URL, "droplets", TOKEN, body)
   end
 
   def self.delete_server(droplet_id)
-    delete(BASE_URL, "droplets/#{droplet_id}", TOKEN)
+    delete(BASE_URL, "droplets/#{droplet_id}", TOKEN, nil)
   end
 
   def self.list_servers
-    get(BASE_URL, "droplets", TOKEN)
+    get(BASE_URL, "droplets", TOKEN, nil)
   end
 end

--- a/lib/astral_plane/http_client/digital_ocean.rb
+++ b/lib/astral_plane/http_client/digital_ocean.rb
@@ -1,11 +1,43 @@
 class AstralPlane::DigitalOcean < AstralPlane::AbstractHttpClient
   BASE_URL = 'https://api.digitalocean.com/v2/'.freeze
 
+  def self.restart_server(droplet_id)
+    body = '{"type":"reboot"}'
+    post("droplets/#{droplet_id}/actions", body, "token")
+  end
+
+  def self.create_server(body)
+    post("droplets", body, "token")
+  end
+
+  def self.delete_server(droplet_id)
+    delete("droplets/#{droplet_id}", "token")
+  end
+
   def self.list_servers
-    get("droplets", "")
+    get("droplets", "token")
   end
 
   def self.get(base_url = BASE_URL, endpoint, token)
+    super_array = super
+    request = super_array[0]
+    http = super_array[1]
+    request['content-type'] = "application/json"
+
+    get_response(http, request)
+  end
+
+  def self.post(base_url = BASE_URL, endpoint, body, token)
+    super_array = super
+    request = super_array[0]
+    http = super_array[1]
+    request['content-type'] = "application/json"
+    request.body = body
+
+    get_response(http, request)
+  end
+
+  def self.delete(base_url = BASE_URL, endpoint, token)
     super_array = super
     request = super_array[0]
     http = super_array[1]

--- a/lib/astral_plane/http_client/digital_ocean.rb
+++ b/lib/astral_plane/http_client/digital_ocean.rb
@@ -1,0 +1,16 @@
+class AstralPlane::DigitalOcean < AstralPlane::AbstractHttpClient
+  BASE_URL = 'https://api.digitalocean.com/v2/'.freeze
+
+  def self.list_servers
+    get("droplets", "")
+  end
+
+  def self.get(base_url = BASE_URL, endpoint, token)
+    super_array = super
+    request = super_array[0]
+    http = super_array[1]
+    request['content-type'] = "application/json"
+
+    get_response(http, request)
+  end
+end


### PR DESCRIPTION
Adds basic http methods for creating, restarting, deleting, and listing servers to the Digital Ocean client.

The client still needs tests, and we need to implement the config to access the token. But I think we can tackle those as separate PRs so that we can build off the code in the abstract client and not block progress on the Heroku http implementation.